### PR TITLE
Add output file specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Here `<model_fname>` is a `lzma` model file, and `<dset_name>` is the dataset na
 
 Usage:
 ```bash
-    ./evaluate.py <model_fname>
+    ./convert_to_hdf5.py <model_fname>
 ```
 
 ### Exporting MNIST

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Usage:
     ./convert_to_hdf5.py <model_fname>
 ```
 
+See [`output_format_spec.md`](output_format_spec.md) for a specification of the file format.
+
 ### Exporting MNIST
 
 `export_mnist.py` writes the MNIST test dataset to disc in PNG format.

--- a/output_format_spec.md
+++ b/output_format_spec.md
@@ -12,8 +12,8 @@ The file contains the following attributes:
 - `num_classes`: The number of output classes.
 - `num_inputs`: The number of input pixels, i.e., `width * height` of the images the model was trained on.
 - `bits_per_input`: The number of bits used to represent a single pixel.
-- `num_filter_inputs`: The number of bits that are sent to one filter. Should be a power of 2.
-- `num_filter_entries`: The number of entries of the bloom filter array.
+- `num_filter_inputs`: The number of bits that are sent to one filter.
+- `num_filter_entries`: The number of entries of the bloom filter array. Should be a power of 2.
 - `num_filter_hashes`: The number of hash functions used for each bloom filter.
 - `p`: The prime used in the MishMash hash function (`x^3 \mod p) \mod 2^l`, where `l = ln2(num_filter_inputs) * num_filter_hashes`).
   `p` should be representable in exactly `l + 1` bits.

--- a/output_format_spec.md
+++ b/output_format_spec.md
@@ -15,7 +15,7 @@ The file contains the following attributes:
 - `num_filter_inputs`: The number of bits that are sent to one filter.
 - `num_filter_entries`: The number of entries of the bloom filter array. Should be a power of 2.
 - `num_filter_hashes`: The number of hash functions used for each bloom filter.
-- `p`: The prime used in the MishMash hash function (`x^3 \mod p) \mod 2^l`, where `l = ln2(num_filter_inputs) * num_filter_hashes`).
+- `p`: The prime used in the MishMash hash function (`x^3 % p) % 2^l`, where `l = ln2(num_filter_inputs) * num_filter_hashes`).
   `p` should be representable in exactly `l + 1` bits.
 
 ## Datasets

--- a/output_format_spec.md
+++ b/output_format_spec.md
@@ -1,0 +1,24 @@
+# Output Format Spec
+
+This codebase persists models the pickle format.
+However, this format is difficult to work with from any programming language other than Python.
+
+For this reason, the `convert_to_hdf5.py` script converts models to a file format based on [HDF5](https://www.hdfgroup.org/solutions/hdf5/).
+
+The file contains the following attributes:
+- `num_classes`: The number of output classes.
+- `num_inputs`: The number of input pixels, i.e., `width * height` of the images the model was trained on.
+- `bits_per_input`: The number of bits used to represent a single pixel.
+- `num_filter_inputs`: The number of bits that are sent to one filter. Should be a power of 2.
+- `num_filter_entries`: The number of entries of the bloom filter array.
+- `num_filter_hashes`: The number of hash functions used for each bloom filter.
+- `p`: The prime used in the MishMash hash function (`x^3 \mod p) \mod 2^l`, where `l = ln2(num_filter_inputs) * num_filter_hashes`).
+  `p` should be representable in exactly `l + 1` bits.
+
+The file contains three datasets:
+- `binarization_thresholds`:
+  A shape `(width, height, bits_per_input)` `float32` array containing the binarization thresholds for each pixel, used for the thermometer encoding.
+  Thresholds should be sorted, so that the temperature encoding of a pixel can be optained by computing `pixel_intensity >= binarization_thresholds[x, y, :]`.
+- `bloom_filter`: A shape `(num_classes, num_filters, num_filter_entries)` `bool` array of bloom filter array, where `num_filters = num_inputs * bits_per_input / num_filter_inputs`.
+- `input_order`: A shape `(num_inputs * bits_per_input, )` `uint64` array that describes the permutation of bits that the model should implement.
+  To permute a list of `bits`, do `permuted_bits = [bits[i] for i in input_order]`.

--- a/output_format_spec.md
+++ b/output_format_spec.md
@@ -2,8 +2,11 @@
 
 This codebase persists models the pickle format.
 However, this format is difficult to work with from any programming language other than Python.
-
 For this reason, the `convert_to_hdf5.py` script converts models to a file format based on [HDF5](https://www.hdfgroup.org/solutions/hdf5/).
+
+This document specifies the format.
+
+## Attributes
 
 The file contains the following attributes:
 - `num_classes`: The number of output classes.
@@ -14,6 +17,8 @@ The file contains the following attributes:
 - `num_filter_hashes`: The number of hash functions used for each bloom filter.
 - `p`: The prime used in the MishMash hash function (`x^3 \mod p) \mod 2^l`, where `l = ln2(num_filter_inputs) * num_filter_hashes`).
   `p` should be representable in exactly `l + 1` bits.
+
+## Datasets
 
 The file contains three datasets:
 - `binarization_thresholds`:

--- a/software_model/convert_to_hdf5.py
+++ b/software_model/convert_to_hdf5.py
@@ -18,8 +18,9 @@ def convert_model(model_fname):
     model = state_dict["model"]
     info = state_dict["info"]
 
-    assert model_fname.endswith(".lzma")
-    output_path = Path(model_fname[:-5] + ".hdf5")
+    suffix = ".pickle.lzma"
+    assert model_fname.endswith(suffix)
+    output_path = Path(model_fname[:-len(suffix)] + ".hdf5")
 
     if output_path.exists():
         print("Deleting existing output file")


### PR DESCRIPTION
Adds a specification of the output HDF5 format. Also fixes that files output by `convert_to_hdf5.py` have a `.pickle.hdf5` suffix, which does not make any sense.

Resolves https://github.com/zkp-gravity/0g-halo2/issues/3