### PR TITLE
Fix overflow bug

### DIFF
--- a/software_model/bloom_filter.py
+++ b/software_model/bloom_filter.py
@@ -97,7 +97,6 @@ class BloomFilter:
     # Implementation of the add_member function
     # Coding in this style (as a static method) is necessary to use Numba for JIT compilation
     @staticmethod
-    @jit(nopython=True)
     def __add_member(xv, p, hash_bits, num_hashes, data):
         hash_results = mish_mash_hash(xv, p, hash_bits, num_hashes)
         least_entry = data[hash_results].min() # The most times the entry has possibly been previously seen

--- a/software_model/bloom_filter.py
+++ b/software_model/bloom_filter.py
@@ -20,7 +20,6 @@ def h3_hash(xv, m):
         reduction_result ^= selected_entries[:,i]
     return reduction_result
 
-@jit(nopython=True)
 def mish_mash_hash(xv: np.ndarray, p: int, hash_bits: int, num_hashes: int) -> np.ndarray:
     """MishMash hash function: `(x^3 % p) % 2^l`
     
@@ -43,6 +42,9 @@ def mish_mash_hash(xv: np.ndarray, p: int, hash_bits: int, num_hashes: int) -> n
 
     hash = np.zeros(num_hashes, dtype=np.int64)
 
+    # At this point, x is a np.int64, but that could overflow.
+    # Python ints are arbitrary precision, so we convert to that.
+    x = int(x)
     xp = x % p
     x3 = xp * xp * xp
     h = x3 % p
@@ -79,7 +81,6 @@ class BloomFilter:
     # Implementation of the check_membership function
     # Coding in this style (as a static method) is necessary to use Numba for JIT compilation
     @staticmethod
-    @jit(nopython=True)
     def __check_membership(xv, p, hash_bits, num_hashes, bleach, data):
         #hash_results = dietzfelbinger_hash(x, a_values, b_values, num_inputs, index_bits)
         hash_results = mish_mash_hash(xv, p, hash_bits, num_hashes)


### PR DESCRIPTION
There was an overflow bug in the MishMash hash that occurred when training larger models (like MNIST-Medium and MNIST-Large). This PR resolves it by explicitly using python integers (which have arbitrary precision) and not using numba jit (which converts numbers to 64-bit integers).

Unfortunately, not using numba means that the training now takes several hours (4h for MNIST-Medium; 7:50h for MNIST-Large). That's fine for reproducing the BTHOWeN models, but for any type of research we'd have to think of a more efficient implementation (implementing big int in numpy?).